### PR TITLE
Allow entering API key on page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,31 @@ Simple web-based translator between Ukrainian and Polish using ChatGPT API.
    ```
 4. Open `http://localhost:3000` in your browser.
 
+### Deployment notes
+
+The `/translate` endpoint is served by `server.js` and requires a Node.js
+environment. Static hosting services like GitHub Pages do **not** run this
+server, so the translate button will fail with a `405 Method Not Allowed` error
+if you only deploy the contents of the `public` directory.
+
+To use the application online, deploy the server portion to a service capable of
+running Node.js (for example Render, Heroku or another VPS). Then set a global
+`API_BASE` variable before loading `script.js` to point to that server:
+
+```html
+<script>
+  window.API_BASE = 'https://your-server-domain';
+</script>
+<script src="script.js"></script>
+```
+
+When running the frontend and server on the same host (e.g. `localhost`), no
+additional configuration is required.
+
+If you host only the static files (for example on GitHub Pages), you can
+manually provide the API key in the "OpenAI API Key" field that appears above
+the text area. The page will send requests directly to the OpenAI API using this
+key. **Be aware** that anyone who can access the page can view this key, so use
+it only for personal experiments.
+
 Use the dropdowns to set translation tone (friendly or formal) and direction. The swap button flips the translation direction.

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 <body>
   <div class="container glass">
     <h1>AI Перекладач</h1>
+    <input type="password" id="api-key" placeholder="OpenAI API Key" />
     <textarea id="input" placeholder="Введіть текст"></textarea>
     <div class="controls">
       <select id="tone">

--- a/public/style.css
+++ b/public/style.css
@@ -32,6 +32,14 @@ textarea {
   resize: vertical;
 }
 
+input[type="password"] {
+  width: 100%;
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 5px;
+  border: none;
+}
+
 .controls {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add API key input field to the frontend
- allow `public/script.js` to call OpenAI directly when no API base is set
- style the new password field
- document the option and security note

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415e38fe9c83318e8de7529def09d1