### PR TITLE
Add loading animation for translate button

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,6 +48,12 @@ async function translate() {
   const text = document.getElementById('input').value.trim();
   const tone = document.getElementById('tone').value;
   const direction = document.getElementById('direction').value;
+  const btn = document.getElementById('translate');
+  const original = btn ? btn.innerHTML : '';
+  if (btn) {
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+  }
   if (!text) return;
   try {
     if (API_BASE) {
@@ -96,6 +102,11 @@ async function translate() {
     }
   } catch (e) {
     document.getElementById('output').value = 'Error';
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.innerHTML = original;
+    }
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -87,3 +87,8 @@ button {
 #translate.translate-btn:active {
   transform: scale(0.95);
 }
+
+#translate.translate-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- show a spinner on the Translate button while a request is in progress
- disable the button until translation completes
- style disabled state for the translate button

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68416bdebdec8331a0543f2858057c82