### PR TITLE
Add interface labels and copy feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,21 +11,25 @@
 <body>
   <div class="container glass">
     <h1>AI Перекладач</h1>
+    <label for="input">Текст для перекладу</label>
     <textarea id="input" placeholder="Введіть текст"></textarea>
     <div class="controls">
-      <select id="tone">
+      <label for="tone" title="Офіційно, Розмовно, З гумором та інші стилі">Стиль перекладу:</label>
+      <select id="tone" title="Офіційно, Розмовно, З гумором та інші стилі">
         <option value="friendly">Дружньо</option>
         <option value="formal">Офіційно</option>
       </select>
-      <button id="swap">⇄</button>
+      <button id="swap" class="swap-btn" title="Поміняти мови місцями">⇄</button>
       <select id="direction">
         <option value="ua-pl">UA → PL</option>
         <option value="pl-ua">PL → UA</option>
       </select>
     </div>
     <button id="translate" class="translate-btn"><i class="fas fa-language"></i></button>
+    <label for="output">Результат перекладу</label>
     <textarea id="output" placeholder="Переклад" readonly></textarea>
-    <button id="settings-btn"><i class="fas fa-cog"></i></button>
+    <button id="copy-btn" title="Скопіювати переклад"><i class="fas fa-copy"></i></button>
+    <button id="settings-btn" title="Налаштування перекладача"><i class="fas fa-cog"></i></button>
     <div id="settings" class="settings glass">
       <input type="password" id="api-key" placeholder="OpenAI API Key" />
     </div>

--- a/script.js
+++ b/script.js
@@ -124,3 +124,15 @@ if (inputField) {
     }
   });
 }
+
+const copyBtn = document.getElementById('copy-btn');
+const outputField = document.getElementById('output');
+if (copyBtn && outputField) {
+  copyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(outputField.value);
+    } catch (e) {
+      /* noop */
+    }
+  });
+}

--- a/style.css
+++ b/style.css
@@ -32,8 +32,8 @@ select {
   padding: 12px;
   font-family: inherit;
   border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(5px);
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
   resize: vertical;
@@ -52,6 +52,16 @@ select:focus {
   justify-content: space-between;
   align-items: center;
   gap: 8px;
+}
+
+.swap-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .settings {
@@ -96,6 +106,19 @@ button {
   position: absolute;
   bottom: 16px;
   right: 16px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#copy-btn {
+  position: absolute;
+  bottom: 16px;
+  right: 56px;
   width: 32px;
   height: 32px;
   padding: 0;


### PR DESCRIPTION
## Summary
- add labels for source and translated text fields
- provide translation style label and tooltip
- tweak menu/button styling and add swap-btn style
- add copy button with clipboard functionality
- make inputs more contrasted
- position copy button next to settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684199f1bcb48331b1b0e4c3c710d673