### PR TITLE
Refine translate button look

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <h1>AI Перекладач</h1>
     <label for="input">Текст для перекладу</label>
     <textarea id="input" placeholder="Введіть текст"></textarea>
+    <button id="translate" class="translate-btn"><i class="fas fa-language"></i></button>
     <div class="controls">
       <label for="tone" title="Офіційно, Розмовно, З гумором та інші стилі">Стиль перекладу:</label>
       <select id="tone" title="Офіційно, Розмовно, З гумором та інші стилі">
@@ -25,7 +26,6 @@
         <option value="pl-ua">PL → UA</option>
       </select>
     </div>
-    <button id="translate" class="translate-btn"><i class="fas fa-language"></i></button>
     <label for="output">Результат перекладу</label>
     <textarea id="output" placeholder="Переклад" readonly></textarea>
     <button id="copy-btn" title="Скопіювати переклад"><i class="fas fa-copy"></i></button>

--- a/style.css
+++ b/style.css
@@ -87,7 +87,8 @@ button {
   width: 64px;
   height: 64px;
   padding: 0;
-  border-radius: 50%;
+  /* Square button with slightly rounded corners */
+  border-radius: 8px;
   background: #4caf50;
   color: #fff;
   font-size: 24px;


### PR DESCRIPTION
## Summary
- keep translate button after the input field
- round translate button corners to 8px

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68419fe4b37c8331a80f56c98748e2c8