### PR TITLE
Refine translate API prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,45 @@ access the page can view this key, so use it only for personal experiments.
 
 Use the dropdowns to set translation tone (friendly or formal) and direction.
 The swap button flips the translation direction.
+
+### Example API Request
+
+To directly call the OpenAI API for translating from Ukrainian to Polish you can
+send the following JSON payload:
+
+```http
+POST https://api.openai.com/v1/chat/completions
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Ти професійний перекладач з української на польську. Перекладай точно і природно."
+    },
+    {
+      "role": "user",
+      "content": "Переклади фразу: \"Моя донька любить морозиво і котиків.\""
+    }
+  ],
+  "temperature": 0.2
+}
+```
+
+The expected response contains the translated phrase in `choices[0].message.cont
+ent`:
+
+```json
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "Moja córka lubi lody i kotki."
+      }
+    }
+  ]
+}
+```

--- a/script.js
+++ b/script.js
@@ -20,7 +20,8 @@ if (settingsBtn && settings) {
 
 const API_BASE = window.API_BASE || '';
 const API_URL = 'https://api.openai.com/v1/chat/completions';
-const MODEL = 'gpt-3.5-turbo';
+const MODEL = 'gpt-4';
+const TEMPERATURE = 0.2;
 
 const API_KEY_STORAGE = 'openai-api-key';
 
@@ -75,8 +76,10 @@ async function translate() {
         return;
       }
       const [from, to] = direction.split('-');
-      const style = tone === 'formal' ? 'офіційно' : 'дружньо';
-      const prompt = `Переклади з ${from === 'ua' ? 'української' : 'польської'} на ${to === 'ua' ? 'українську' : 'польську'} ${style}.`;
+      const base = `Ти професійний перекладач з ${from === 'ua' ? 'української' : 'польської'} на ${to === 'ua' ? 'українську' : 'польську'}. Перекладай точно і природно.`;
+      const toneNote = tone === 'formal'
+        ? 'Використовуй офіційний тон.'
+        : 'Використовуй дружній тон.';
 
       const res = await fetch(API_URL, {
         method: 'POST',
@@ -86,10 +89,10 @@ async function translate() {
         },
         body: JSON.stringify({
           model: MODEL,
+          temperature: TEMPERATURE,
           messages: [
-            { role: 'system', content: prompt },
-            { role: 'system', content: tone === 'formal' ? 'Використовуй офіційний тон.' : 'Використовуй дружній тон.' },
-            { role: 'user', content: text }
+            { role: 'system', content: `${base} ${toneNote}` },
+            { role: 'user', content: `Переклади фразу: "${text}"` }
           ]
         })
       });


### PR DESCRIPTION
## Summary
- use explicit professional translator prompt in `translate` function
- add formal/informal note to the system message
- phrase user message as "Переклади фразу" with the input text

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842a36f54fc8331af77a52020e588d3