### PR TITLE
UI overhaul with tone buttons

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -5,17 +5,15 @@ describe('script.js', () => {
     document.body.innerHTML = `
       <input id="api-key" />
       <button id="swap"></button>
-      <select id="direction">
-        <option value="ua-pl">UA → PL</option>
-        <option value="pl-ua">PL → UA</option>
-      </select>
-      <button id="translate"></button>
+      <button class="direction-btn active" data-value="ua-pl"></button>
+      <button class="direction-btn" data-value="pl-ua"></button>
+      <button id="translate-friendly"></button>
+      <button id="translate-formal"></button>
       <textarea id="input"></textarea>
-      <select id="tone">
-        <option value="friendly">friendly</option>
-        <option value="formal">formal</option>
-      </select>
       <textarea id="output"></textarea>
+      <button id="clear-input"></button>
+      <button id="copy-input"></button>
+      <button id="copy-btn"></button>
     `;
     window.API_BASE = '/api';
     localStorage.clear();
@@ -30,18 +28,18 @@ describe('script.js', () => {
 
   test('swap button toggles direction and swaps text', () => {
     require('../script.js');
-    const dir = document.getElementById('direction');
+    const ua = document.querySelector('.direction-btn[data-value="ua-pl"]');
+    const pl = document.querySelector('.direction-btn[data-value="pl-ua"]');
     const input = document.getElementById('input');
     const output = document.getElementById('output');
-    dir.value = 'ua-pl';
     input.value = 'a';
     output.value = 'b';
     document.getElementById('swap').click();
-    expect(dir.value).toBe('pl-ua');
+    expect(pl.classList.contains('active')).toBe(true);
     expect(input.value).toBe('b');
     expect(output.value).toBe('a');
     document.getElementById('swap').click();
-    expect(dir.value).toBe('ua-pl');
+    expect(ua.classList.contains('active')).toBe(true);
     expect(input.value).toBe('a');
     expect(output.value).toBe('b');
   });
@@ -53,9 +51,7 @@ describe('script.js', () => {
       json: async () => ({ translation: 'hello' }),
     });
     document.getElementById('input').value = 'test';
-    document.getElementById('direction').value = 'ua-pl';
-    document.getElementById('tone').value = 'friendly';
-    document.getElementById('translate').click();
+    document.getElementById('translate-friendly').click();
     await new Promise(r => setTimeout(r, 0));
     expect(global.fetch).toHaveBeenCalledWith('/api/translate', expect.objectContaining({
       method: 'POST',
@@ -70,7 +66,7 @@ describe('script.js', () => {
       json: async () => ({ error: 'fail' }),
     });
     document.getElementById('input').value = 'text';
-    document.getElementById('translate').click();
+    document.getElementById('translate-friendly').click();
     await new Promise(r => setTimeout(r, 0));
     expect(document.getElementById('output').value).toBe('fail');
   });
@@ -79,7 +75,7 @@ describe('script.js', () => {
     require('../script.js');
     global.fetch.mockRejectedValue(new Error('network'));
     document.getElementById('input').value = 'text';
-    document.getElementById('translate').click();
+    document.getElementById('translate-friendly').click();
     await new Promise(r => setTimeout(r, 0));
     expect(document.getElementById('output').value).toBe('Error');
   });
@@ -87,7 +83,7 @@ describe('script.js', () => {
   test('does not call fetch when text is empty', async () => {
     require('../script.js');
     document.getElementById('input').value = '';
-    document.getElementById('translate').click();
+    document.getElementById('translate-friendly').click();
     await new Promise(r => setTimeout(r, 0));
     expect(global.fetch).not.toHaveBeenCalled();
   });

--- a/index.html
+++ b/index.html
@@ -13,25 +13,25 @@
 	<h1>AI Перекладач (gpt-4)</h1>
 	<div class="text-container">
 		<label for="input">Текст для перекладу</label>
-		<div class="input-container">
-			<textarea id="input" placeholder="Введіть текст"></textarea>
-			<button id="translate" class="translate-btn action-btn"><i class="fas fa-language"></i></button>
-		</div>
-	</div>
-	<div class="controls">
-		<label for="tone">Стиль</label>
-		<select id="tone">
-			<option value="friendly">Дружньо</option>
-			<option value="formal">Офіційно</option>
-		</select>
-		<button id="swap" class="swap-btn" title="Поміняти мови місцями">
-			<i class="fa-solid fa-right-left"></i>
-		</button>
-		<select id="direction">
-			<option value="ua-pl">UA → PL</option>
-			<option value="pl-ua">PL → UA</option>
-		</select>
-	</div>
+                <div class="input-container">
+                        <textarea id="input" placeholder="Введіть текст"></textarea>
+                        <div class="vertical-btns">
+                                <button id="clear-input" class="icon-btn" title="Очистити"><i class="fas fa-xmark"></i></button>
+                                <button id="copy-input" class="icon-btn" title="Скопіювати текст"><i class="fas fa-copy"></i></button>
+                        </div>
+                </div>
+        </div>
+        <div class="controls">
+                <button id="translate-friendly" class="action-btn">Дружньо</button>
+                <button id="translate-formal" class="action-btn">Офіційно</button>
+        </div>
+        <div class="controls">
+                <button class="direction-btn active" id="dir-ua-pl" data-value="ua-pl">UA → PL</button>
+                <button id="swap" class="swap-btn" title="Поміняти мови місцями">
+                        <i class="fa-solid fa-right-left"></i>
+                </button>
+                <button class="direction-btn" id="dir-pl-ua" data-value="pl-ua">PL → UA</button>
+        </div>
 	<div class="text-container">
 		<label for="output">Результат перекладу</label>
 		<div class="input-container">

--- a/script.js
+++ b/script.js
@@ -1,22 +1,36 @@
 document.getElementById('swap').addEventListener('click', () => {
-	const dir = document.getElementById('direction');
-	dir.value = dir.value === 'ua-pl' ? 'pl-ua' : 'ua-pl';
-	const input = document.getElementById('input');
-	const output = document.getElementById('output');
-	if (input && output) {
-		const tmp = input.value;
-		input.value = output.value;
-		output.value = tmp;
-	}
+        const current = document.querySelector('.direction-btn.active');
+        if (!current) return;
+        const next = current.dataset.value === 'ua-pl'
+                ? document.querySelector('.direction-btn[data-value="pl-ua"]')
+                : document.querySelector('.direction-btn[data-value="ua-pl"]');
+        if (next) {
+                current.classList.remove('active');
+                next.classList.add('active');
+        }
+        const input = document.getElementById('input');
+        const output = document.getElementById('output');
+        if (input && output) {
+                const tmp = input.value;
+                input.value = output.value;
+                output.value = tmp;
+        }
 });
 
 const settingsBtn = document.getElementById('settings-btn');
 const settings = document.getElementById('settings');
 if (settingsBtn && settings) {
-	settingsBtn.addEventListener('click', () => {
-		settings.classList.toggle('show');
-	});
+        settingsBtn.addEventListener('click', () => {
+                settings.classList.toggle('show');
+        });
 }
+
+document.querySelectorAll('.direction-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+                document.querySelectorAll('.direction-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+        });
+});
 
 const API_BASE = window.API_BASE || '';
 const API_URL = 'https://api.openai.com/v1/chat/completions';
@@ -41,91 +55,110 @@ if (apiKeyInput) {
 }
 
 function getApiKey() {
-	return document.getElementById('api-key')?.value.trim();
+        return document.getElementById('api-key')?.value.trim();
 }
 
-async function translate() {
-	const text = document.getElementById('input').value.trim();
-	const tone = document.getElementById('tone').value;
-	const direction = document.getElementById('direction').value;
-	const btn = document.getElementById('translate');
-	const original = btn ? btn.innerHTML : '';
-	if (btn) {
-		btn.disabled = true;
-		btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
-	}
-	if (!text) return;
-	try {
-		if (API_BASE) {
-			const res = await fetch(`${API_BASE}/translate`, {
-				method: 'POST',
-				headers: {'Content-Type': 'application/json'},
-				body: JSON.stringify({text, direction, tone})
-			});
-			const data = await res.json();
-			if (data.translation) {
-				document.getElementById('output').value = data.translation;
-			} else {
+async function translate(tone, btn) {
+        const text = document.getElementById('input').value.trim();
+        const direction = document.querySelector('.direction-btn.active')?.dataset.value || 'ua-pl';
+        const original = btn ? btn.innerHTML : '';
+        if (btn) {
+                btn.disabled = true;
+                btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+        }
+        if (!text) {
+                if (btn) {
+                        btn.disabled = false;
+                        btn.innerHTML = original;
+                }
+                return;
+        }
+        try {
+                if (API_BASE) {
+                        const res = await fetch(`${API_BASE}/translate`, {
+                                method: 'POST',
+                                headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({text, direction, tone})
+                        });
+                        const data = await res.json();
+                        if (data.translation) {
+                                document.getElementById('output').value = data.translation;
+                        } else {
 				document.getElementById('output').value = data.error || 'Error';
 			}
 		} else {
-			const apiKey = getApiKey();
-			if (!apiKey) {
-				document.getElementById('output').value = 'API key required';
-				return;
-			}
-			const [from, to] = direction.split('-');
-			const base = `Ти професійний перекладач з ${from === 'ua' ? 'української' : 'польської'} на ${to === 'ua' ? 'українську' : 'польську'}. Перекладай точно і природно.`;
-			const toneNote = tone === 'formal'
-				? 'Використовуй офіційний тон.'
-				: 'Використовуй дружній тон.';
+                        const apiKey = getApiKey();
+                        if (!apiKey) {
+                                document.getElementById('output').value = 'API key required';
+                                return;
+                        }
+                        const [from, to] = direction.split('-');
+                        const base = `Ти професійний перекладач з ${from === 'ua' ? 'української' : 'польської'} на ${to === 'ua' ? 'українську' : 'польську'}. Перекладай точно і природно.`;
+                        const toneNote = tone === 'formal'
+                                ? 'Використовуй офіційний тон.'
+                                : 'Використовуй дружній тон.';
 
-			const res = await fetch(API_URL, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Bearer ${apiKey}`
-				},
-				body: JSON.stringify({
-					model: MODEL,
-					messages: [
-						{role: 'system', content: `${base} ${toneNote}`},
-						{role: 'user', content: `Переклади фразу: ${text}`}
-					]
-				})
-			});
-			if (!res.ok) {
-				const errorData = await res.json();
-				document.getElementById('output').value = errorData.error?.message || 'Error';
-				return;
-			}
-			const data = await res.json();
-			const result = data.choices?.[0]?.message?.content?.trim() || '';
-			document.getElementById('output').value = result;
-		}
-	} catch (e) {
-		document.getElementById('output').value = 'Error';
-	} finally {
-		if (btn) {
-			btn.disabled = false;
-			btn.innerHTML = original;
-		}
-	}
+                        const res = await fetch(API_URL, {
+                                method: 'POST',
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                        'Authorization': `Bearer ${apiKey}`
+                                },
+                                body: JSON.stringify({
+                                        model: MODEL,
+                                        messages: [
+                                                {role: 'system', content: `${base} ${toneNote}`},
+                                                {role: 'user', content: `Переклади фразу: ${text}`}
+                                        ]
+                                })
+                        });
+                        if (!res.ok) {
+                                const errorData = await res.json();
+                                document.getElementById('output').value = errorData.error?.message || 'Error';
+                                return;
+                        }
+                        const data = await res.json();
+                        const result = data.choices?.[0]?.message?.content?.trim() || '';
+                        document.getElementById('output').value = result;
+                }
+        } catch (e) {
+                document.getElementById('output').value = 'Error';
+        } finally {
+                if (btn) {
+                        btn.disabled = false;
+                        btn.innerHTML = original;
+                }
+        }
 }
 
-const translateBtn = document.getElementById('translate');
-if (translateBtn) {
-	translateBtn.addEventListener('click', translate);
+const friendlyBtn = document.getElementById('translate-friendly');
+if (friendlyBtn) {
+        friendlyBtn.addEventListener('click', () => translate('friendly', friendlyBtn));
 }
 
-const inputField = document.getElementById('input');
-if (inputField) {
-	inputField.addEventListener('keydown', e => {
-		if (e.key === 'Enter' && !e.shiftKey) {
-			e.preventDefault();
-			translate();
-		}
-	});
+const formalBtn = document.getElementById('translate-formal');
+if (formalBtn) {
+        formalBtn.addEventListener('click', () => translate('formal', formalBtn));
+}
+
+const clearInputBtn = document.getElementById('clear-input');
+if (clearInputBtn) {
+        clearInputBtn.addEventListener('click', () => {
+                const input = document.getElementById('input');
+                if (input) input.value = '';
+        });
+}
+
+const copyInputBtn = document.getElementById('copy-input');
+if (copyInputBtn) {
+        copyInputBtn.addEventListener('click', async () => {
+                const input = document.getElementById('input');
+                try {
+                        if (input) await navigator.clipboard.writeText(input.value);
+                } catch (e) {
+                        /* noop */
+                }
+        });
 }
 
 const copyBtn = document.getElementById('copy-btn');

--- a/style.css
+++ b/style.css
@@ -35,9 +35,26 @@ body {
 }
 
 .input-container {
-	display: flex;
-	flex-direction: row;
-	gap: 16px;
+        display: flex;
+        flex-direction: row;
+        gap: 16px;
+}
+
+.vertical-btns {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+}
+
+.icon-btn {
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.7);
 }
 
 textarea,
@@ -119,17 +136,17 @@ button {
 }
 
 .action-btn:active {
-	box-shadow: inset 3px 3px 6px #b5b5b5, inset -3px -3px 6px #ffffff;
+        box-shadow: inset 3px 3px 6px #b5b5b5, inset -3px -3px 6px #ffffff;
 }
 
-
-#translate:disabled {
-	opacity: 0.6;
-	cursor: not-allowed;
+.direction-btn {
+        padding: 8px 12px;
+        background: rgba(255, 255, 255, 0.7);
 }
 
-#direction {
-	width: 100px;
+.direction-btn.active {
+        background: rgba(255, 255, 255, 1);
+        box-shadow: inset 3px 3px 6px #b5b5b5, inset -3px -3px 6px #ffffff;
 }
 
 .translate-container {


### PR DESCRIPTION
## Summary
- revamp index layout: add clear/copy buttons near input
- replace translation tone dropdown with dedicated buttons
- replace direction select with toggle buttons
- adjust styles for new buttons
- rewrite translation logic for new controls
- update unit tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685061cbd22883318245621029106744